### PR TITLE
Change of ui image

### DIFF
--- a/charts/jisort/Chart.yaml
+++ b/charts/jisort/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/jisort/templates/_helpers.tpl
+++ b/charts/jisort/templates/_helpers.tpl
@@ -66,8 +66,12 @@ Return Hikari JDBC URL
 Return Tenant Database Name
 */}}
 {{- define "tenant.databaseName" -}}
-{{- printf "fineract_%s" .Values.tenant.identifier -}}
+{{- printf "fineract_default" -}}
 {{- end -}}
+
+{{/*
+Return Server Protocol
+*/}}
 {{- define "server.protocol" -}}
 {{- if .Values.server.ssl.enabled -}}
 {{- printf "HTTPS" -}}
@@ -75,4 +79,3 @@ Return Tenant Database Name
 {{- printf "HTTP" -}}
 {{- end -}}
 {{- end -}}
-

--- a/charts/jisort/templates/deployment.yaml
+++ b/charts/jisort/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             - name: FINERACT_DEFAULT_TENANTDB_TIMEZONE
               value: {{ .Values.tenant.timezone }}
             - name: FINERACT_DEFAULT_TENANTDB_IDENTIFIER
-              value: {{ .Values.tenant.identifier }}
+              value: 'default'
             - name: FINERACT_DEFAULT_TENANTDB_NAME
               value: {{ include "tenant.databaseName" . }}
             - name: FINERACT_DEFAULT_TENANTDB_DESCRIPTION

--- a/charts/jisort/templates/deployment.yaml
+++ b/charts/jisort/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/component: server
     spec:
       initContainers:
-        - name: check-{{ .Values.tenant.identifier }}-db
+        - name: check-db
           image: busybox:1.28
           command:
             [
@@ -25,7 +25,7 @@ spec:
               "-c",
               'echo -e "Checking for availability of MySQL server deployment"; while ! nc -z {{ include "database.host" . }} {{ include "database.port" . }}; do sleep 1; printf "-"; done; echo -e " >> MySQL server has started";',
             ]
-        - name: init-{{ .Values.tenant.identifier }}-db
+        - name: init-db
           image: litmuschaos/mysql-client:latest
           command:
             [
@@ -44,7 +44,7 @@ spec:
                   name: {{ include "database.secretName" . }}
                   key: {{ include "database.secretKeyRoot" . }}
       containers:
-        - name: fs-{{ .Values.tenant.identifier }}
+        - name: fs-{{ include "common.names.fullname" . }}
           image: truehostcloud/mifos-server
           resources: {{- toYaml .Values.server.resources | nindent 12 }}
           ports:

--- a/charts/jisort/templates/ui/deployment.yaml
+++ b/charts/jisort/templates/ui/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             ]
       containers:
         - name: fw-{{ .Values.tenant.identifier }}
-          image: truehostcloud/mifos-community
+          image: truehostcloud/mifos-web-app
           resources: {{- toYaml .Values.client.resources | nindent 12 }}
           livenessProbe:
             httpGet:

--- a/charts/jisort/templates/ui/deployment.yaml
+++ b/charts/jisort/templates/ui/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/component: web
     spec:
       initContainers:
-        - name: check-{{ .Values.tenant.identifier }}-server
+        - name: check-server
           image: busybox:1.28
           command:
             [
@@ -26,7 +26,7 @@ spec:
               'echo -e "Checking the availability of Fineract server deployment"; while ! nc -z {{ include "common.names.fullname" . }}-server {{ .Values.server.port }}; do sleep 1; printf "-"; done; echo -e " >> Fineract server has started";',
             ]
       containers:
-        - name: fw-{{ .Values.tenant.identifier }}
+        - name: fw-{{ include "common.names.fullname" . }}
           image: truehostcloud/mifos-web-app
           resources: {{- toYaml .Values.client.resources | nindent 12 }}
           livenessProbe:

--- a/charts/jisort/templates/ui/service.yaml
+++ b/charts/jisort/templates/ui/service.yaml
@@ -10,5 +10,5 @@ spec:
     app.kubernetes.io/component: web
   ports:
     - protocol: TCP
-      port: 9090
+      port: 4200
       targetPort: 80

--- a/charts/jisort/values.yaml
+++ b/charts/jisort/values.yaml
@@ -34,8 +34,6 @@ mysql:
 tenant:
   ## @param tenant.connectionParams Tenant connection parameters
   connectionParams: ""
-  ## @param tenant.identifier Tenant identifier
-  identifier: "default"
   ## @param tenant.name Tenant name
   name: "Default Tenant"
   ## @param tenant.timezone Tenant timezone


### PR DESCRIPTION
## What is the Purpose?

Changing of the UI from using the [community-app](https://github.com/openMF/community-app) to using the [web-app](https://github.com/openMF/web-app). This is because the community-app is not under active development as compared to the web-app which in turn has functionalities that are outdated and not working with the new fineract server.

## What was the approach?

Change the image repo in the ui deployment.yml file. Since by default the web-app uses tenantIdentifier as default, we change all references to .Values.tenant.identifier accordingly (where not needed, we removed the reference and where needed, we use the value default)

## Are there any concerns to addressed further before or after merging this PR?

None

## Mentions?

@willymwai 

## Issue(s) affected?

Closes #2 
