### PR TITLE
feat(jisort): bump to version 0.2.3

### DIFF
--- a/charts/jisort/Chart.yaml
+++ b/charts/jisort/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/jisort/templates/deployment.yaml
+++ b/charts/jisort/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
                   key: {{ include "database.secretKeyRoot" . }}
       containers:
         - name: fs-{{ include "common.names.fullname" . }}
-          image: "{{ .Values.server.image.name }}"
+          image: "{{ .Values.server.image.name }}:{{ .Values.server.image.tag }}"
           resources: {{- toYaml .Values.server.resources | nindent 12 }}
           ports:
             - containerPort: {{ .Values.server.port }}

--- a/charts/jisort/templates/deployment.yaml
+++ b/charts/jisort/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
                   key: {{ include "database.secretKeyRoot" . }}
       containers:
         - name: fs-{{ include "common.names.fullname" . }}
-          image: truehostcloud/mifos-server
+          image: "{{ .Values.server.image.name }}"
           resources: {{- toYaml .Values.server.resources | nindent 12 }}
           ports:
             - containerPort: {{ .Values.server.port }}

--- a/charts/jisort/values.yaml
+++ b/charts/jisort/values.yaml
@@ -51,6 +51,7 @@ server:
   port: 8080
   image:
     name: truehostcloud/mifos-server
+    tag: 0.0.2
   resources:
     limits: {}
     requests: {}

--- a/charts/jisort/values.yaml
+++ b/charts/jisort/values.yaml
@@ -49,6 +49,8 @@ server:
   ssl:
     enabled: false
   port: 8080
+  image:
+    name: truehostcloud/mifos-server
   resources:
     limits: {}
     requests: {}


### PR DESCRIPTION
## What is the Purpose?
Bumps jisort helm chart to version 0.2.3. This will trigger a new release of the chart with the latest changes to mifos-server image.

## What was the approach?
Bump the version in the Chart.yaml file.

## How can the changes made get tested?
- Some of the pentaho reports should be fixed.
- The MySQL driver should be present in the classpath.

## Are there any concerns to addressed further before or after merging this PR?
N/A

## Mentions?
N/A

## Issue(s) affected?
Milestone: https://github.com/truehostcloud/jisort/milestone/57
Issue: https://github.com/truehostcloud/jisort/issues/2275