### PR TITLE
feat(jisort): upgrade to `mifos-server` 0.0.3

### DIFF
--- a/charts/jisort/Chart.yaml
+++ b/charts/jisort/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/jisort/values.yaml
+++ b/charts/jisort/values.yaml
@@ -51,7 +51,7 @@ server:
   port: 8080
   image:
     name: truehostcloud/mifos-server
-    tag: 0.0.2
+    tag: 0.0.3
   resources:
     limits: {}
     requests: {}


### PR DESCRIPTION
## What is the Purpose?
Updates the `mifos-server` dependency to `0.0.3` which includes the following changes:
- Adds pentaho `.pprt` report files to the docker image

## What was the approach?
- Copy the files into the docker image as they aren't included in the jar files

## How can the changes made get tested?
- Pentaho reports should be able to be rendered without missing pprt file error

## Are there any concerns to addressed further before or after merging this PR?
This env variable `FINERACT_PENTAHO_REPORTS_PATH=/pentahoReports` should be set so that pentaho knows where to search for the pprt files.

## Mentions?

## Issue(s) affected?
Milestone: https://github.com/truehostcloud/jisort/milestone/57
Issue: https://github.com/truehostcloud/jisort/issues/2275